### PR TITLE
Use tool version from `peerDependencies`

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -20,7 +20,7 @@ const spawn = require('await-spawn');
 const { URL } = require('url');
 
 const { castArray } = require('./utils');
-const { version } = require('../package.json');
+const { version, peerDependencies } = require('../package.json');
 
 const npm = require.resolve(path.join(globalDirs.npm.binaries, 'npm'));
 const npx = importFrom(path.join(globalDirs.npm.packages, 'npm'), 'libnpx');
@@ -91,12 +91,14 @@ function runCommands(commands, params = {}) {
       return spawn(process.argv0, [npm, ...args], { stdio: 'inherit' });
     }
     const npxArgs = ['--quiet'];
+    const pkgVersion = peerDependencies[pkg];
+    const spec = [pkg, pkgVersion].join('@');
     if (bin === 'yo') {
-      npxArgs.push(...['-p', 'yo', '-p', pkg, '--', 'yo', ...args]);
+      npxArgs.push(...['-p', 'yo', '-p', spec, '--', bin, ...args]);
     } else if (bin !== pkg) {
-      npxArgs.push(...['-p', pkg, '-c', bin, ...args]);
+      npxArgs.push(...['-p', spec, '--', bin, ...args]);
     } else {
-      npxArgs.push(...[bin, ...args]);
+      npxArgs.push(...[spec, ...args]);
     }
     // eslint-disable-next-line no-console
     console.error(chalk.dim('\n> npx %s'), npxArgs.join(' '));

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -29,6 +29,7 @@ const spawn = require('await-spawn');
 /* eslint-enable */
 
 const { runCommands, generateChoices, selectTool } = require('../bin/main');
+const { peerDependencies } = require('../package.json');
 
 describe('selectTool', () => {
   const choices = {
@@ -108,8 +109,12 @@ describe('runCommands', () => {
       [npm, 'pack', '--dry-run'],
       { stdio: 'inherit' },
     );
+    const [, comm] = tools.publish.comm;
+    const pkg = comm.bin;
+    const pkgVersion = peerDependencies[pkg];
+    const spec = [pkg, pkgVersion].join('@');
     expect(mockNpx.parseArgs).toHaveBeenCalledWith(
-      [...process.argv, '--quiet', 'np'],
+      [...process.argv, '--quiet', spec],
       npm,
     );
   });


### PR DESCRIPTION
Invoke `npx` with full package specifier containing version listed in `peerDependencies` section of `package.json`.